### PR TITLE
chore: Add `node_modules/` to `.gitignore`

### DIFF
--- a/es6-skills/.gitignore
+++ b/es6-skills/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules/


### PR DESCRIPTION
For people like me who don't have it globally for some silly reason. 