### PR TITLE
Docker environment

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+# The docker environment and scripts create a bunch of temporary files that we don't need
+*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    curl && \
+    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
+    sudo apt-get install -y nodejs && \
+    npm install -g webpack
+
+ADD npm-deps /opt/npm-deps
+
+RUN cd /opt/npm-deps/webpack && npm install && cd /opt/npm-deps/skills && npm install
+
+ADD entrypoint /usr/bin/entrypoint
+
+ENTRYPOINT ["entrypoint"]
+
+WORKDIR /root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,6 @@ RUN apt-get update && apt-get install -y \
     sudo apt-get install -y nodejs && \
     npm install -g webpack
 
-ADD npm-deps /opt/npm-deps
-
-RUN cd /opt/npm-deps/webpack && npm install && cd /opt/npm-deps/skills && npm install
-
 ADD entrypoint /usr/bin/entrypoint
 
 ENTRYPOINT ["entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,6 @@
-FROM ubuntu:16.04
+FROM node:6-slim
 
-RUN apt-get update && apt-get install -y \
-    sudo \
-    curl && \
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
-    sudo apt-get install -y nodejs && \
-    npm install -g webpack
+RUN npm install -g webpack
 
 ADD entrypoint /usr/bin/entrypoint
 

--- a/docker/build-and-run
+++ b/docker/build-and-run
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+realpath_portable() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+command -v docker &>/dev/null || {
+    echo "Install docker first:  https://docs.docker.com/engine/installation/"
+    exit 1
+}
+
+mkdir -p ${DIR}/npm-deps/{webpack,skills}
+echo "Copying dependencies..."
+cp "${DIR}/../my-first-module/package.json" ${DIR}/npm-deps/webpack/package.json
+cp "${DIR}/../es6-skills/package.json" ${DIR}/npm-deps/skills/package.json
+
+WORKSPACE=$(realpath_portable "${DIR}/../")
+docker build -t br-modern-javascript-exercises ${DIR}
+echo "${WORKSPACE}:/root"
+
+exec docker run -v"${WORKSPACE}:/root" -it br-modern-javascript-exercises  /bin/bash

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -2,6 +2,21 @@
 
 echo "
 
+##########################################################
+Setting up node environments, this may take a few minutes!
+##########################################################
+
+"
+
+pushd /root/es6-skills
+npm install
+pushd /root/my-first-module
+npm install
+popd
+popd
+
+echo "
+
 ####################################################################################################################################
 You're in a Docker environment!  Type exit to leave (or control-D).  You can also find all the examples at your home directory /root
 ####################################################################################################################################

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "
+
+####################################################################################################################################
+You're in a Docker environment!  Type exit to leave (or control-D).  You can also find all the examples at your home directory /root
+####################################################################################################################################
+
+helpful commands:
+
+    ls          list files
+    cd          change directory
+    nodejs      use NodeJS to evaluate scripts
+
+"
+
+exec /bin/bash


### PR DESCRIPTION
If you have Docker installed you can run these tests through a Docker environment.  The environment will have NodeJS and an Ubuntu-like interface.

To start developing go to docker and run ./build-and-run

It will build the image, enter it, and install NodeJS dependencies.  Here is some example output:

```./build-and-run
Copying dependencies...
Sending build context to Docker daemon  9.728kB
Step 1/5 : FROM ubuntu:16.04
 ---> 2d696327ab2e
Step 2/5 : RUN apt-get update && apt-get install -y     sudo     curl &&     curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - &&     sudo apt-get install -y nodejs &&     npm install -g webpack
 ---> Using cache
 ---> 24bfae0b4e71
Step 3/5 : ADD entrypoint /usr/bin/entrypoint
 ---> Using cache
 ---> 48854e5a725f
Step 4/5 : ENTRYPOINT entrypoint
 ---> Using cache
 ---> 9e4410adc148
Step 5/5 : WORKDIR /root
 ---> Using cache
 ---> 5a62b1a6cf28
Successfully built 5a62b1a6cf28
Successfully tagged br-modern-javascript-exercises:latest
/Users/claffer2/br-js-exercises/br-modern-javascript-exercises/docker/..:/root


##########################################################
Setting up node environments, this may take a few minutes!
##########################################################


~/es6-skills ~
npm WARN es6-skills@1.0.0 No repository field.
~/my-first-module ~/es6-skills ~
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.0.0 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN my-first-module@1.0.0 No repository field.
~/es6-skills ~
~


####################################################################################################################################
You're in a Docker environment!  Type exit to leave (or control-D).  You can also find all the examples at your home directory /root
####################################################################################################################################

helpful commands:

    ls          list files
    cd          change directory
    nodejs      use NodeJS to evaluate scripts


root@7cc11c78323d:~#
```

You can then go to the folders and execute them:

```cd my-first-module
webpack
```

```(node:27) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
Hash: bdac0a4cdd41e8847203
Version: webpack 2.7.0
Time: 5137ms
      Asset    Size  Chunks                    Chunk Names
    dist.js  302 kB       0  [emitted]  [big]  main
dist.js.map  592 kB       0  [emitted]         main
   [1] ./app.js 281 bytes {0} [built]
   [2] ./~/jquery/dist/jquery.js 297 kB {0} [built]
   [3] (webpack)/buildin/module.js 521 bytes {0} [built]
    + 1 hidden modules
```

Tested to work on a Mac, probably will work on Linux too.